### PR TITLE
feat: send score to API after winning

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,12 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+  <link rel="manifest" href="manifest.webmanifest">
+  <link rel="apple-touch-icon" href="stitch.png">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-title" content="Kosmiczna Misja Stisia">
+  <meta name="apple-mobile-web-app-status-bar-style" content="default">
+  <meta name="theme-color" content="#0b1220">
   <title>Kosmiczna Misja Stisia — gra matematyczna</title>
   <style>
     :root{
@@ -60,6 +66,8 @@
 
     .footer{display:flex; justify-content:space-between; align-items:center; gap:8px; margin-top:auto}
     .primary{background:linear-gradient(90deg,#34a3ff,#5fe3ff); color:#05223f}
+
+    .buildInfo{text-align:center; font-size:12px; color:var(--muted); margin-top:8px}
 
     .hidden{display:none}
     .shake{animation:shake .38s cubic-bezier(.36,.07,.19,.97) both}
@@ -148,6 +156,7 @@
         <button class="btn primary" id="againBtn">Zagraj ponownie</button>
       </div>
     </section>
+    <div id="buildInfo" class="buildInfo small"></div>
   </div>
 
   <canvas class="celebrate" id="confetti" width="1920" height="1080"></canvas>
@@ -589,7 +598,7 @@
           score: state.score,
           timeMs: Date.now() - state.startTime
         };
-        fetch('https://mgxscoreapi-dgbzagg8dkdpd3b9.canadacentral-01.azurewebsites.net/scores', {
+        fetch('https://mgxscoreapi-dgbzagg8dkdpd3b9.canadacentral-01.azurewebsites.net/score', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(payload)
@@ -637,24 +646,41 @@
       const startX=Math.random()*window.innerWidth;
       const targetX=Math.random()*window.innerWidth;
       const targetY=Math.random()*window.innerHeight;
-      r.style.transform=`translate(${startX}px,-60px) rotate(90deg)`;
+      const angle=Math.atan2(targetY+60,targetX-startX)*180/Math.PI;
+      const rotation=angle+45; // Adjust for emoji's default 45deg orientation and rotate 90° clockwise
+      r.style.transform=`translate(${startX}px,-60px) rotate(${rotation}deg)`;
       r.offsetWidth;
-      r.style.transform=`translate(${targetX}px,${targetY}px) rotate(135deg)`;
-      r.addEventListener('transitionend',()=>{r.remove(); boom(targetX,targetY);},{once:true});
+      r.style.transform=`translate(${targetX}px,${targetY}px) rotate(${rotation}deg)`;
+      r.addEventListener('transitionend',()=>{
+        const rect=r.getBoundingClientRect();
+        const rad=Math.atan2(targetY+60,targetX-startX);
+        const headX=rect.left+rect.width/2+Math.cos(rad)*rect.height/2;
+        const headY=rect.top+rect.height/2+Math.sin(rad)*rect.height/2;
+        r.remove();
+        boom(headX,headY);
+      },{once:true});
     }
     function boom(x,y){
-      const b=document.createElement('div');
-      b.className='boom';
-      b.textContent='💥';
-      b.style.left=`${x}px`;
-      b.style.top=`${y}px`;
-      document.body.appendChild(b);
-      setTimeout(()=>b.remove(),700);
+      const count=3+Math.floor(Math.random()*4);
+      for(let i=0;i<count;i++){
+        const b=document.createElement('div');
+        b.className='boom';
+        b.textContent='💥';
+        const ang=Math.random()*Math.PI*2;
+        const dist=10+Math.random()*30;
+        b.style.left=`${x+Math.cos(ang)*dist}px`;
+        b.style.top=`${y+Math.sin(ang)*dist}px`;
+        document.body.appendChild(b);
+        setTimeout(()=>b.remove(),700);
+      }
     }
     (function rocketLoop(){
       const delay=5000+Math.random()*10000;
       setTimeout(()=>{spawnRocket(); rocketLoop();},delay);
     })();
+
+    document.getElementById('buildInfo').textContent =
+      'Wersja z: ' + new Date(document.lastModified).toLocaleString('pl-PL');
 
     // Start gry
     renderQuestion();

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -1,0 +1,16 @@
+{
+  "name": "Kosmiczna Misja Stisia",
+  "short_name": "Stisia",
+  "start_url": "/Math10y/",
+  "scope": "/Math10y/",
+  "display": "standalone",
+  "background_color": "#0b1220",
+  "theme_color": "#0b1220",
+  "icons": [
+    {
+      "src": "stitch.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- track game start time and reset it on restart
- prompt for player name and post score, time, and icon to the scoring API upon successful game completion

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d930e2f48325b03d3209ba596fc2