### PR TITLE
Add PWA meta tags for iOS fullscreen

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,12 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+  <link rel="manifest" href="manifest.webmanifest">
+  <link rel="apple-touch-icon" href="stitch.png">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-title" content="Kosmiczna Misja Stisia">
+  <meta name="apple-mobile-web-app-status-bar-style" content="default">
+  <meta name="theme-color" content="#0b1220">
   <title>Kosmiczna Misja Stisia — gra matematyczna</title>
   <style>
     :root{

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -1,0 +1,15 @@
+{
+  "name": "Kosmiczna Misja Stisia",
+  "short_name": "Stisia",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#0b1220",
+  "theme_color": "#0b1220",
+  "icons": [
+    {
+      "src": "stitch.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- enable standalone mode on iOS by adding Apple-specific meta tags and theme color
- create web manifest to support add-to-home-screen experience

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c28a89bb008325ba4376fcbb1aaf07