### PR TITLE
Fix API endpoint for score submission

### DIFF
--- a/index.html
+++ b/index.html
@@ -598,7 +598,7 @@
           score: state.score,
           timeMs: Date.now() - state.startTime
         };
-        fetch('https://mgxscoreapi-dgbzagg8dkdpd3b9.canadacentral-01.azurewebsites.net/score', {
+        fetch('http://mgxscoreapi-dgbzagg8dkdpd3b9.canadacentral-01.azurewebsites.net/scores', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(payload)


### PR DESCRIPTION
## Summary
- update score submission endpoint to use `/scores` path and http scheme

## Testing
- `curl -i http://mgxscoreapi-dgbzagg8dkdpd3b9.canadacentral-01.azurewebsites.net/scores -H "Content-Type: application/json" -d '{"game":"Tetris","playerName":"Mariusz","playerIcon":"mariusz.png","score":1500,"timeMs":32000}'` *(fails: Domain forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c2a2a575d4832592468068ec267809