### PR TITLE
Use HTTPS for score API

### DIFF
--- a/index.html
+++ b/index.html
@@ -598,7 +598,7 @@
           score: state.score,
           timeMs: Date.now() - state.startTime
         };
-        fetch('http://mgxscoreapi-dgbzagg8dkdpd3b9.canadacentral-01.azurewebsites.net/scores', {
+        fetch('https://mgxscoreapi-dgbzagg8dkdpd3b9.canadacentral-01.azurewebsites.net/scores', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(payload)


### PR DESCRIPTION
## Summary
- Switch score-saving request to HTTPS to avoid mixed-content errors

## Testing
- ⚠️ `npm test` (no package.json)


------
https://chatgpt.com/codex/tasks/task_e_68c2a510e92883258a8e9e6e15da686a