### PR TITLE
Remove version display and update scoreboard

### DIFF
--- a/Level01.html
+++ b/Level01.html
@@ -67,7 +67,6 @@
     .footer{display:flex; justify-content:space-between; align-items:center; gap:8px; margin-top:auto}
     .primary{background:linear-gradient(90deg,#34a3ff,#5fe3ff); color:#05223f}
 
-    .buildInfo{text-align:center; font-size:12px; color:var(--muted); margin-top:8px}
 
     .hidden{display:none}
     .shake{animation:shake .38s cubic-bezier(.36,.07,.19,.97) both}
@@ -156,7 +155,6 @@
         <button class="btn primary" id="againBtn">Zagraj ponownie</button>
       </div>
     </section>
-    <div id="buildInfo" class="buildInfo small"></div>
   </div>
 
   <canvas class="celebrate" id="confetti" width="1920" height="1080"></canvas>
@@ -678,9 +676,6 @@
       const delay=5000+Math.random()*10000;
       setTimeout(()=>{spawnRocket(); rocketLoop();},delay);
     })();
-
-    document.getElementById('buildInfo').textContent =
-      'Wersja z: ' + new Date(document.lastModified).toLocaleString('pl-PL');
 
     // Start gry
     renderQuestion();

--- a/index.html
+++ b/index.html
@@ -31,11 +31,12 @@
     .container{width:100%; max-width:980px; margin:0 auto; padding:calc(10px + env(safe-area-inset-top)) 12px calc(10px + env(safe-area-inset-bottom)) 12px; min-height:100dvh; display:flex; flex-direction:column; gap:20px; align-items:center; justify-content:center; text-align:center}
     .panel{background:var(--card); border:1px solid rgba(255,255,255,.06); border-radius:16px; padding:14px; box-shadow:0 10px 26px rgba(5,12,28,.45); width:100%; max-width:400px}
     .title{font-size: clamp(24px, 4vw, 40px); font-weight:800}
-    .scoreItem{display:flex; justify-content:space-between; align-items:center; padding:4px 0; border-bottom:1px solid rgba(255,255,255,.05)}
+    .scoreItem{display:grid; grid-template-columns:1fr auto auto; gap:8px; align-items:center; padding:4px 0; border-bottom:1px solid rgba(255,255,255,.05)}
     .scoreItem:last-child{border-bottom:none}
     .playerBox{display:flex; align-items:center; gap:8px}
     .avatar{width:32px; height:32px; border-radius:50%; object-fit:cover; box-shadow:0 2px 4px rgba(0,0,0,.25)}
     .scoreMeta{display:block; font-size:.5em; color:var(--muted)}
+    .scoreDate{font-size:.8em; color:var(--muted); text-align:center}
     .muted{color:var(--muted)}
 
     .btn{padding:12px 20px; border-radius:12px; border:1px solid rgba(255,255,255,.12); background:#0f1d38; color:var(--text); cursor:pointer; font-weight:700; text-align:center; transition: transform .08s ease, border-color .2s, background .2s; user-select:none}
@@ -85,10 +86,11 @@
           row.className = 'scoreItem';
           const avatar = playerIcon || 'stitch.png';
           const timeStr = formatTime(timeMs);
-          const dateStr = registeredAt ? new Date(registeredAt).toLocaleString('pl-PL') : '';
+          const dateStr = registeredAt ? new Date(registeredAt).toLocaleString('pl-PL') : '-';
           row.innerHTML = `
             <span class="playerBox"><img src="${avatar}" class="avatar" alt=""><span>${playerName || 'Anonim'}</span></span>
-            <span>${score}<span class="scoreMeta">${timeStr}${dateStr ? '<br>' + dateStr : ''}</span></span>`;
+            <span class="scoreDate">${dateStr}</span>
+            <span>${score}<span class="scoreMeta">${timeStr}</span></span>`;
           list.appendChild(row);
         });
         scoresBox.innerHTML = '';


### PR DESCRIPTION
## Summary
- remove version info from Level01 game page
- add separate date column on score screen

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c3e05d5b488325a11d12962e7e9f8b