### PR TITLE
Add hero selection before starting game

### DIFF
--- a/Level01.html
+++ b/Level01.html
@@ -110,10 +110,10 @@
   <div class="container">
     <header>
       <div class="titleBox">
-        <img src="stitch.png" class="mascot" alt="Stiś">
+        <img src="stitch.png" class="mascot" alt="Bohater">
         <div>
           <div class="title">Kosmiczna Misja Stisia</div>
-          <div class="small">Pomóż niebieskiemu kosmicie Stisiowi zbierać ananasy, rozwiązując zadania z matematyki! 🍍</div>
+          <div class="small">Pomóż wybranemu bohaterowi zbierać ananasy, rozwiązując zadania z matematyki! 🍍</div>
         </div>
       </div>
       <div class="scoreRow">
@@ -134,7 +134,7 @@
       <div class="options" id="options"></div>
 
       <div class="speech">
-        <img src="stitch.png" class="mascot" style="width:48px; height:48px" alt="Stiś">
+        <img src="stitch.png" class="mascot" style="width:48px; height:48px" alt="Bohater">
         <div class="bubble small" id="hint">Kliknij poprawną odpowiedź. Za dobrą odpowiedź: +10 punktów i ananas 🟡. Za błąd tracisz serduszko.</div>
       </div>
 
@@ -160,6 +160,10 @@
   <canvas class="celebrate" id="confetti" width="1920" height="1080"></canvas>
 
   <script>
+    const HERO = localStorage.getItem('selectedHero') || 'stitch.png';
+    const HERO_NAMES = { 'stitch.png':'Stiś', 'robo.png':'Robo', 'astro.png':'Astro' };
+    const HERO_NAME = HERO_NAMES[HERO] || 'Bohater';
+    document.querySelectorAll('.mascot').forEach(img => img.src = HERO);
     // --- Małe gwiazdki w tle ---
     (function makeStars(){
       const box = document.getElementById('stars');
@@ -474,7 +478,7 @@
       if(opt.correct){
         btn.classList.add('correct');
         state.score += 10;
-        elHint.textContent = 'Brawo! Stiś znalazł ananasa! 🍍 +10 punktów';
+        elHint.textContent = `Brawo! ${HERO_NAME} znalazł ananasa! 🍍 +10 punktów`;
         confetti();
         isCorrect=true;
       } else {
@@ -584,7 +588,7 @@
 
       // Tekst nad listą
       elSummaryText && (elSummaryText.textContent = completed
-        ? `Misja zakończona! Stiś jest dumny! 🚀`
+        ? `Misja zakończona! ${HERO_NAME} jest dumny! 🚀`
         : `Koniec żyć. Spróbuj ponownie — wierzymy w Ciebie! 💪`);
 
       if (completed) {
@@ -592,7 +596,7 @@
         const payload = {
           game: 'Math10y',
           playerName,
-          playerIcon: 'stitch.png',
+          playerIcon: HERO,
           score: state.score,
           timeMs: Date.now() - state.startTime
         };

--- a/index.html
+++ b/index.html
@@ -44,6 +44,10 @@
     .btn:active{transform:translateY(0)}
     .primary{background:linear-gradient(90deg,#34a3ff,#5fe3ff); color:#05223f}
 
+    .heroGrid{display:flex; gap:12px; justify-content:center; margin-top:10px}
+    .heroGrid img{width:80px; height:80px; border-radius:50%; cursor:pointer; border:2px solid transparent; object-fit:cover; transition:transform .15s, border-color .15s}
+    .heroGrid img:hover{transform:scale(1.1); border-color:var(--accent)}
+
     .buildInfo{text-align:center; font-size:12px; color:var(--muted); margin-top:8px}
   </style>
 </head>
@@ -54,7 +58,15 @@
     <div id="scoresBox" class="panel">
       <p class="muted">Ładowanie wyników...</p>
     </div>
-    <button id="startBtn" class="btn primary" onclick="location.href='Level01.html'">Start gry</button>
+    <button id="startBtn" class="btn primary">Start gry</button>
+    <div id="heroBox" class="panel" style="display:none">
+      <p>Wybierz bohatera:</p>
+      <div class="heroGrid">
+        <img src="stitch.png" data-hero="stitch.png" alt="Stiś">
+        <img src="robo.png" data-hero="robo.png" alt="Robo">
+        <img src="astro.png" data-hero="astro.png" alt="Astro">
+      </div>
+    </div>
     <div class="buildInfo" id="buildInfo"></div>
   </div>
   <script>
@@ -114,6 +126,19 @@
     }
 
     document.getElementById('buildInfo').textContent = 'Wersja z: ' + new Date(document.lastModified).toLocaleString('pl-PL');
+
+    const startBtn = document.getElementById('startBtn');
+    const heroBox = document.getElementById('heroBox');
+    startBtn.addEventListener('click', () => {
+      heroBox.style.display = 'block';
+      startBtn.style.display = 'none';
+    });
+    document.querySelectorAll('#heroBox img').forEach(img => {
+      img.addEventListener('click', () => {
+        localStorage.setItem('selectedHero', img.dataset.hero);
+        location.href = 'Level01.html';
+      });
+    });
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- allow players to pick from Stitch, Robo or Astro before starting the game
- remember the chosen hero and load it in the level, updating mascots and score submission
- use hero name in in-game messages and summary
- remove unused apple touch icon update

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c3f0e009748325a976ec7804cb4d09