### PR TITLE
feat: enable lemonade production

### DIFF
--- a/Level02.html
+++ b/Level02.html
@@ -18,11 +18,23 @@
       75%{transform:var(--base) rotate(-3deg)}
       100%{transform:var(--base)}
     }
+
+    #hud{position:fixed;bottom:20px;left:50%;transform:translateX(-50%);display:flex;gap:12px;align-items:center;background:rgba(255,255,255,.8);padding:10px 16px;border-radius:12px;font-family:sans-serif;z-index:5}
+    #hud .stock{font-weight:700}
+    #hud button{padding:8px 12px;font-size:16px;cursor:pointer;border-radius:8px;border:1px solid #ccc;background:#fff}
+    #hud .yellow{color:#facc15}
+    #hud .red{color:#ef4444}
   </style>
 </head>
 <body>
   <div id="map">
     <img id="shop" src="LemonShop.png" alt="Lemon Shop">
+  </div>
+  <div id="hud">
+    <div class="stock yellow">Yellow: <span id="yellowStock">0</span></div>
+    <div class="stock red">Red: <span id="redStock">0</span></div>
+    <button id="makeYellow">Make Yellow</button>
+    <button id="makeRed">Make Red</button>
   </div>
   <script>
     const treeImages=['Tree-1.png','Tree-2.png','Tree-3.png'];
@@ -75,6 +87,21 @@
     }
 
     window.addEventListener('load', placeTrees);
+
+    const yellowStockEl=document.getElementById('yellowStock');
+    const redStockEl=document.getElementById('redStock');
+    let yellowStock=0;
+    let redStock=0;
+
+    document.getElementById('makeYellow').addEventListener('click',()=>{
+      yellowStock++;
+      yellowStockEl.textContent=yellowStock;
+    });
+
+    document.getElementById('makeRed').addEventListener('click',()=>{
+      redStock++;
+      redStockEl.textContent=redStock;
+    });
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add on-screen HUD with stock counters for yellow and red lemonade
- allow producing yellow or red lemonade via dedicated buttons

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c7f6a784b4832589322b61ccfbd80f