### PR TITLE
Show cups on lemon cart for produced drinks

### DIFF
--- a/Level02.html
+++ b/Level02.html
@@ -11,6 +11,10 @@
     #shopWrapper{position:absolute;top:20px;left:50%;transform:translateX(-50%);width:400px;z-index:2}
     #shopWrapper{position:relative}
     #shop{width:100%;height:auto;display:block}
+    #cart{position:absolute;bottom:60px;left:50%;transform:translateX(-50%);width:260px;height:80px;display:flex;justify-content:space-between;pointer-events:none}
+    .cartSide{display:flex;flex-wrap:wrap;width:48%;gap:4px;align-content:flex-start}
+    .cup{position:relative;font-size:28px;line-height:1}
+    .cup .fruit{position:absolute;top:-6px;right:-6px;font-size:16px}
     .producer{position:absolute;top:50%;transform:translateY(-50%);display:flex;flex-direction:column;align-items:center}
     .producer.left{left:-130px}
     .producer.right{right:-130px}
@@ -34,6 +38,10 @@
   <div id="map">
     <div id="shopWrapper">
       <img id="shop" src="LemonShop.png" alt="Lemon Shop">
+      <div id="cart">
+        <div id="cartYellow" class="cartSide"></div>
+        <div id="cartRed" class="cartSide"></div>
+      </div>
       <div class="producer left">
         <div id="yellowStock" class="count yellow">0</div>
         <button id="makeYellow" class="yellow">🍋</button>
@@ -98,17 +106,29 @@
 
     const yellowStockEl=document.getElementById('yellowStock');
     const redStockEl=document.getElementById('redStock');
+    const cartYellow=document.getElementById('cartYellow');
+    const cartRed=document.getElementById('cartRed');
     let yellowStock=0;
     let redStock=0;
+
+    function addCup(type){
+      const cup=document.createElement('span');
+      cup.className='cup';
+      const fruit=type==='yellow'?'🍋':'🍓';
+      cup.innerHTML=`🥤<span class="fruit">${fruit}</span>`;
+      if(type==='yellow') cartYellow.appendChild(cup); else cartRed.appendChild(cup);
+    }
 
     document.getElementById('makeYellow').addEventListener('click',()=>{
       yellowStock++;
       yellowStockEl.textContent=yellowStock;
+      addCup('yellow');
     });
 
     document.getElementById('makeRed').addEventListener('click',()=>{
       redStock++;
       redStockEl.textContent=redStock;
+      addCup('red');
     });
   </script>
 </body>


### PR DESCRIPTION
## Summary
- display a cart area for cups in the lemon shop
- add cup icons with lemon or strawberry markers when drinks are produced

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c80743506883258235889c335d8fc0