### PR TITLE
Reposition hero selectors around keypad zero

### DIFF
--- a/Level03.html
+++ b/Level03.html
@@ -62,19 +62,24 @@
 
     .operationInfo{background:#0a1428; border:1px solid rgba(255,255,255,.08); border-radius:12px; padding:10px 12px; line-height:1.4}
 
-    .padLayout{display:grid; grid-template-columns:minmax(0,1fr) minmax(0,clamp(220px,45vw,340px)) minmax(0,1fr); gap:16px; align-items:stretch; width:100%}
-    .padColumn{display:flex; flex-direction:column; align-items:stretch; gap:12px; width:100%}
+    .padLayout{display:flex; justify-content:center; width:100%}
+    .padColumn{display:flex; flex-direction:column; align-items:center; gap:12px; width:100%; max-width:clamp(240px, 60vw, 360px)}
 
     .avatar{display:flex; flex-direction:column; gap:12px; align-items:center; justify-content:center; border-radius:14px; border:1px solid rgba(255,255,255,.08); background:#0f1d38; padding:14px 12px; color:var(--text); cursor:pointer; transition:transform .12s ease, border-color .2s ease, box-shadow .2s ease; min-width:0; text-align:center}
     .avatar img{width:60px; height:60px; border-radius:50%; box-shadow:0 6px 16px rgba(0,0,0,.35); object-fit:cover}
     .avatar .avatarMeta{display:flex; flex-direction:column; gap:4px; align-items:center}
     .avatar .small{font-size:13px; color:var(--muted)}
+    .pad .avatar{width:100%; padding:clamp(8px, 2vw, 12px); gap:clamp(6px, 1.8vw, 10px); border-radius:18px}
+    .pad .avatar img{width:clamp(40px, 11vw, 56px); height:clamp(40px, 11vw, 56px)}
+    .pad .avatar .avatarMeta{gap:6px}
+    .pad .avatar strong{font-size:clamp(14px, 3.4vw, 16px)}
+    .pad .avatar .small{font-size:clamp(12px, 3vw, 14px); color:var(--muted)}
     .avatar.active{border-color:var(--accent); box-shadow:0 10px 22px rgba(60,140,255,.35)}
     .avatar:focus-visible{outline:2px solid var(--accent); outline-offset:4px}
 
     .pad{display:grid; grid-template-columns:repeat(3,minmax(0,1fr)); gap:12px; width:100%; max-width:100%; margin:0}
-    .padColumn .pad{max-width:360px}
-    .padColumn .hint{width:100%}
+    .padColumn .pad{width:100%}
+    .padColumn .hint{width:100%; text-align:center}
 
     .hint{background:#0a1a33; border:1px dashed rgba(255,255,255,.1); padding:10px 12px; border-radius:10px; color:var(--muted)}
 
@@ -112,9 +117,8 @@
       .pad{gap:10px}
     }
     @media (max-width:560px){
-      .padLayout{grid-template-columns:minmax(0,1fr); grid-auto-flow:row; justify-items:center; gap:12px}
-      .padLayout > .avatar{width:100%; max-width:260px}
-      .padLayout > .padColumn{width:100%; max-width:320px}
+      .padLayout{gap:12px}
+      .padColumn{max-width:320px}
     }
     @media (max-width:480px){
       .avatar img{width:48px; height:48px}
@@ -171,24 +175,10 @@
       <div class="operationInfo small" id="operationInfo">Wybierz działanie, aby zobaczyć wskazówkę.</div>
 
       <div class="padLayout" role="group" aria-label="Wybierz bohatera do przesuwania">
-        <button type="button" class="avatar active" data-hero="0">
-          <img id="heroAImg" src="stitch.png" alt="Pierwszy bohater">
-          <div class="avatarMeta">
-            <strong id="hero0Name">Stiś</strong>
-            <div class="small">Cyfra: <span id="hero0Choice">?</span></div>
-          </div>
-        </button>
         <div class="padColumn">
-          <div class="pad" id="pad" role="grid" aria-label="Panel cyfr"></div>
+          <div class="pad" id="pad" role="grid" aria-label="Panel cyfr i bohaterów"></div>
           <div class="hint small" id="hint">Kliknij bohatera, aby go aktywować, a następnie wybierz cyfrę z panelu. Gdy oba pola będą ustawione, wciśnij przycisk CHECK.</div>
         </div>
-        <button type="button" class="avatar" data-hero="1">
-          <img id="heroBImg" src="robo.png" alt="Drugi bohater">
-          <div class="avatarMeta">
-            <strong id="hero1Name">Robo</strong>
-            <div class="small">Cyfra: <span id="hero1Choice">?</span></div>
-          </div>
-        </button>
       </div>
 
       <button type="button" class="btn primary" id="checkBtn">CHECK</button>
@@ -209,10 +199,6 @@
     document.documentElement.style.setProperty('--hero0', `url("${HERO}")`);
     document.documentElement.style.setProperty('--hero1', `url("${SIDEKICK}")`);
     document.getElementById('leadHero').src = HERO;
-    document.getElementById('heroAImg').src = HERO;
-    document.getElementById('heroBImg').src = SIDEKICK;
-    document.getElementById('hero0Name').textContent = HERO_NAME;
-    document.getElementById('hero1Name').textContent = SIDEKICK_NAME;
     document.getElementById('subtitle').textContent = `${HERO_NAME} i ${SIDEKICK_NAME} muszą otworzyć portale liczbowe!`;
 
     (function makeStars(){
@@ -230,23 +216,57 @@
       }
     })();
 
+    const heroDetails = [
+      {image: HERO, name: HERO_NAME, alt: 'Pierwszy bohater'},
+      {image: SIDEKICK, name: SIDEKICK_NAME, alt: 'Drugi bohater'}
+    ];
+
     const pad = document.getElementById('pad');
-    const layout = [7,8,9,4,5,6,1,2,3,null,0,null];
-    layout.forEach(val => {
-      if(val === null){
-        const spacer=document.createElement('div');
-        spacer.className='spacer';
-        spacer.setAttribute('aria-hidden','true');
-        pad.appendChild(spacer);
-      }else{
+    const heroNodes = [];
+
+    function createHeroButton(heroIndex){
+      const info = heroDetails[heroIndex];
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = `avatar${heroIndex === 0 ? ' active' : ''}`;
+      btn.dataset.hero = String(heroIndex);
+      btn.setAttribute('aria-pressed', heroIndex === 0 ? 'true' : 'false');
+      btn.setAttribute('aria-label', `${info.name} — wybierz cyfrę`);
+      const img = document.createElement('img');
+      img.src = info.image;
+      img.alt = info.alt;
+      btn.appendChild(img);
+      const meta = document.createElement('div');
+      meta.className = 'avatarMeta';
+      const nameEl = document.createElement('strong');
+      nameEl.textContent = info.name;
+      meta.appendChild(nameEl);
+      const small = document.createElement('div');
+      small.className = 'small';
+      small.textContent = 'Cyfra: ';
+      const value = document.createElement('span');
+      value.textContent = '?';
+      small.appendChild(value);
+      meta.appendChild(small);
+      btn.appendChild(meta);
+      heroNodes[heroIndex] = {button: btn, choiceEl: value};
+      return btn;
+    }
+
+    const layout = [7,8,9,4,5,6,1,2,3,'hero0',0,'hero1'];
+    layout.forEach(item => {
+      if(typeof item === 'number'){
         const btn=document.createElement('button');
         btn.type='button';
         btn.className='key';
-        btn.dataset.digit=String(val);
+        btn.dataset.digit=String(item);
         btn.setAttribute('role','gridcell');
-        btn.setAttribute('aria-label',`Cyfra ${val}`);
-        btn.textContent=val;
+        btn.setAttribute('aria-label',`Cyfra ${item}`);
+        btn.textContent=item;
         pad.appendChild(btn);
+      }else if(item === 'hero0' || item === 'hero1'){
+        const index = item === 'hero0' ? 0 : 1;
+        pad.appendChild(createHeroButton(index));
       }
     });
 
@@ -261,8 +281,8 @@
     const feedbackEl = document.getElementById('feedback');
     const checkBtn = document.getElementById('checkBtn');
     const resetBtn = document.getElementById('resetBtn');
-    const heroButtons = Array.from(document.querySelectorAll('.avatar'));
-    const heroChoiceEls = [document.getElementById('hero0Choice'), document.getElementById('hero1Choice')];
+    const heroButtons = heroNodes.map(node => node.button);
+    const heroChoiceEls = heroNodes.map(node => node.choiceEl);
     const eqA = document.getElementById('eqA');
     const eqB = document.getElementById('eqB');
     const eqOp = document.getElementById('eqOp');
@@ -419,7 +439,11 @@
 
     function setActiveHero(index){
       activeHero = index;
-      heroButtons.forEach(btn => btn.classList.toggle('active', Number(btn.dataset.hero) === index));
+      heroButtons.forEach(btn => {
+        const isActive = Number(btn.dataset.hero) === index;
+        btn.classList.toggle('active', isActive);
+        btn.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+      });
     }
 
     function updateEquation(){


### PR DESCRIPTION
## Summary
- center the keypad layout and restyle hero selector buttons to flank the zero key
- build hero selector buttons inside the keypad grid and update their accessibility state handling

## Testing
- not run (static HTML)


------
https://chatgpt.com/codex/tasks/task_e_68d047c425288325a42f58ffb76d38ff